### PR TITLE
Add pgAdmin service to docker-compose configuration

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -28,6 +28,16 @@ services:
       - "5432:5432"
     volumes:
       - pgdata:/var/lib/postgresql/data
+  
+  pgadmin:
+    image: dpage/pgadmin4
+    environment:
+      PGADMIN_DEFAULT_EMAIL: admin@admin.com
+      PGADMIN_DEFAULT_PASSWORD: admin
+    ports:
+      - "5050:80"
+    depends_on:
+      - db
 
   mailcatcher:
     container_name: adoclic-mailcatcher


### PR DESCRIPTION
Added a new `pgadmin` service to `docker-compose.yaml` using the `dpage/pgadmin4` image. Configured environment variables (`PGADMIN_DEFAULT_EMAIL` and `PGADMIN_DEFAULT_PASSWORD`) for default admin access. Exposed port `5050` on the host, mapped to port `80` in the container. Defined a dependency on the `db` service using the `depends_on` directive.